### PR TITLE
1352 rename gobierto data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem "gobierto_data", git: "https://github.com/PopulateTools/gobierto_data.git"
+gem "gobierto_budgets_data", git: "https://github.com/PopulateTools/gobierto_budgets_data.git"
 gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
-  remote: https://github.com/PopulateTools/gobierto_data.git
-  revision: 8eccea7e0abbe1a47d34e563f64812a6df83b6fc
+  remote: https://github.com/PopulateTools/gobierto_budgets_data.git
+  revision: 7db1fa4d63f08ca30d334255469144bdbc246673
   specs:
-    gobierto_data (0.1.0)
+    gobierto_budgets_data (0.1.0)
       actionpack (>= 5.0.0.1)
       activesupport (>= 5.0.0)
       aws-sdk (~> 2.11, >= 2.11.45)
@@ -98,7 +98,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
-  gobierto_data!
+  gobierto_budgets_data!
 
 BUNDLED WITH
    2.1.4

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ETL scripts for Gobierto Reus site
 
 Edit `.env.example` and copy it to `.env` or `.rbenv-vars` with the expected values.
 
-This repository relies heavily in [gobierto_data](https://github.com/PopulateTools/gobierto_data)
+This repository relies heavily in [gobierto_budgets_data](https://github.com/PopulateTools/gobierto_budgets_data)
 
 ## Available operations
 

--- a/operations/gobierto_budgets/import-executed-budgets/run.rb
+++ b/operations/gobierto_budgets/import-executed-budgets/run.rb
@@ -3,12 +3,12 @@
 require "bundler/setup"
 Bundler.require
 
-index = GobiertoData::GobiertoBudgets::ES_INDEX_EXECUTED
+index = GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_EXECUTED
 data_file = ARGV[0]
 year = ARGV[1].to_i
 
 puts "[START] import-executed-budgets/run.rb year=#{year} data_file=#{data_file}"
 
-nitems = GobiertoData::GobiertoBudgets::BudgetLinesImporter.new(index: index, year: year, data: JSON.parse(File.read(data_file))).import!
+nitems = GobiertoBudgetsData::GobiertoBudgets::BudgetLinesImporter.new(index: index, year: year, data: JSON.parse(File.read(data_file))).import!
 
 puts "[END] import-executed-budgets/run.rb imported #{nitems} items"

--- a/operations/gobierto_budgets/import-planned-budgets/run.rb
+++ b/operations/gobierto_budgets/import-planned-budgets/run.rb
@@ -3,12 +3,12 @@
 require "bundler/setup"
 Bundler.require
 
-index = GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST
+index = GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST
 data_file = ARGV[0]
 year = ARGV[1].to_i
 
 puts "[START] import-planned-budgets/run.rb year=#{year} data_file=#{data_file}"
 
-nitems = GobiertoData::GobiertoBudgets::BudgetLinesImporter.new(index: index, year: year, data: JSON.parse(File.read(data_file))).import!
+nitems = GobiertoBudgetsData::GobiertoBudgets::BudgetLinesImporter.new(index: index, year: year, data: JSON.parse(File.read(data_file))).import!
 
 puts "[END] import-planned-budgets/run.rb imported #{nitems} items"

--- a/operations/gobierto_budgets/transform-executed/run.rb
+++ b/operations/gobierto_budgets/transform-executed/run.rb
@@ -27,7 +27,7 @@ end
 
 input_file = ARGV[0]
 output_file = ARGV[1]
-kind = ARGV[2] == 'I' ? GobiertoData::GobiertoBudgets::INCOME : GobiertoData::GobiertoBudgets::EXPENSE
+kind = ARGV[2] == 'I' ? GobiertoBudgetsData::GobiertoBudgets::INCOME : GobiertoBudgetsData::GobiertoBudgets::EXPENSE
 year = ARGV[3].to_i
 
 puts "[START] transform-executed/run.rb with file=#{input_file} output=#{output_file} year=#{year}"
@@ -35,7 +35,7 @@ puts "[START] transform-executed/run.rb with file=#{input_file} output=#{output_
 json_data = JSON.parse(File.read(input_file))
 
 place = INE::Places::Place.find_by_slug('reus')
-population = GobiertoData::GobiertoBudgets::Population.get(place.id, year)
+population = GobiertoBudgetsData::GobiertoBudgets::Population.get(place.id, year)
 
 base_data = {
   organization_id: place.id,
@@ -58,7 +58,7 @@ def normalize_data(data, kind)
 end
 
 def process_row(row, functional_data, economic_data, kind)
-  amount = kind == GobiertoData::GobiertoBudgets::INCOME ? row["DRETS RECONEGUTS NETS"].to_f : row["OBLIGACIONS RECONEGUDES"].to_f
+  amount = kind == GobiertoBudgetsData::GobiertoBudgets::INCOME ? row["DRETS RECONEGUTS NETS"].to_f : row["OBLIGACIONS RECONEGUDES"].to_f
   amount = amount.round(2)
   functional_code = row["PROGRAMA"].try(:strip)
   economic_code   = row["ECONÒMICA"].strip
@@ -71,7 +71,7 @@ def process_row(row, functional_data, economic_data, kind)
 
   # Level 3
   economic_code_l3 = economic_code[0..2]
-  if kind == GobiertoData::GobiertoBudgets::EXPENSE
+  if kind == GobiertoBudgetsData::GobiertoBudgets::EXPENSE
     functional_code_l3 = functional_code[0..2]
     functional_data[functional_code_l3] ? functional_data[functional_code_l3] += amount : functional_data[functional_code_l3] = amount
   end
@@ -79,7 +79,7 @@ def process_row(row, functional_data, economic_data, kind)
 
   # Level 2
   economic_code_l2 = economic_code[0..1]
-  if kind == GobiertoData::GobiertoBudgets::EXPENSE
+  if kind == GobiertoBudgetsData::GobiertoBudgets::EXPENSE
     functional_code_l2 = functional_code[0..1]
     functional_data[functional_code_l2] ? functional_data[functional_code_l2] += amount : functional_data[functional_code_l2] = amount
   end
@@ -87,7 +87,7 @@ def process_row(row, functional_data, economic_data, kind)
 
   # Level 1
   economic_code_l1 = economic_code[0]
-  if kind == GobiertoData::GobiertoBudgets::EXPENSE
+  if kind == GobiertoBudgetsData::GobiertoBudgets::EXPENSE
     functional_code_l1 = functional_code[0]
     functional_data[functional_code_l1] ? functional_data[functional_code_l1] += amount : functional_data[functional_code_l1] = amount
   end
@@ -122,8 +122,8 @@ end
 
 functional_data, economic_data = normalize_data(json_data, kind)
 
-output_data = hydratate(data: functional_data, area_name: GobiertoData::GobiertoBudgets::FUNCTIONAL_AREA_NAME, base_data: base_data, kind: kind) +
-  hydratate(data: economic_data, area_name: GobiertoData::GobiertoBudgets::ECONOMIC_AREA_NAME, base_data: base_data, kind: kind)
+output_data = hydratate(data: functional_data, area_name: GobiertoBudgetsData::GobiertoBudgets::FUNCTIONAL_AREA_NAME, base_data: base_data, kind: kind) +
+  hydratate(data: economic_data, area_name: GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME, base_data: base_data, kind: kind)
 
 File.write(output_file, output_data.to_json)
 

--- a/operations/gobierto_budgets/transform-planned-updated/run.rb
+++ b/operations/gobierto_budgets/transform-planned-updated/run.rb
@@ -27,7 +27,7 @@ end
 
 input_file = ARGV[0]
 output_file = ARGV[1]
-kind = ARGV[2] == 'I' ? GobiertoData::GobiertoBudgets::INCOME : GobiertoData::GobiertoBudgets::EXPENSE
+kind = ARGV[2] == 'I' ? GobiertoBudgetsData::GobiertoBudgets::INCOME : GobiertoBudgetsData::GobiertoBudgets::EXPENSE
 year = ARGV[3].to_i
 
 puts "[START] transform-planned-updated/run.rb with file=#{input_file} output=#{output_file} year=#{year}"
@@ -35,7 +35,7 @@ puts "[START] transform-planned-updated/run.rb with file=#{input_file} output=#{
 json_data = JSON.parse(File.read(input_file))
 
 place = INE::Places::Place.find_by_slug('reus')
-population = GobiertoData::GobiertoBudgets::Population.get(place.id, year)
+population = GobiertoBudgetsData::GobiertoBudgets::Population.get(place.id, year)
 
 base_data = {
   organization_id: place.id,
@@ -58,7 +58,7 @@ def normalize_data(data, kind)
 end
 
 def process_row(row, functional_data, economic_data, kind)
-  amount = kind == GobiertoData::GobiertoBudgets::INCOME ? row["PREVISIONS TOTALS"].to_f : row["CRÈDITS TOTALS CONSIGNATS"].to_f
+  amount = kind == GobiertoBudgetsData::GobiertoBudgets::INCOME ? row["PREVISIONS TOTALS"].to_f : row["CRÈDITS TOTALS CONSIGNATS"].to_f
   amount = amount.round(2)
   functional_code = row["PROGRAMA"].try(:strip)
   economic_code   = row["ECONÒMICA"].strip
@@ -71,7 +71,7 @@ def process_row(row, functional_data, economic_data, kind)
 
   # Level 3
   economic_code_l3 = economic_code[0..2]
-  if kind == GobiertoData::GobiertoBudgets::EXPENSE
+  if kind == GobiertoBudgetsData::GobiertoBudgets::EXPENSE
     functional_code_l3 = functional_code[0..2]
     functional_data[functional_code_l3] ? functional_data[functional_code_l3] += amount : functional_data[functional_code_l3] = amount
   end
@@ -79,7 +79,7 @@ def process_row(row, functional_data, economic_data, kind)
 
   # Level 2
   economic_code_l2 = economic_code[0..1]
-  if kind == GobiertoData::GobiertoBudgets::EXPENSE
+  if kind == GobiertoBudgetsData::GobiertoBudgets::EXPENSE
     functional_code_l2 = functional_code[0..1]
     functional_data[functional_code_l2] ? functional_data[functional_code_l2] += amount : functional_data[functional_code_l2] = amount
   end
@@ -87,7 +87,7 @@ def process_row(row, functional_data, economic_data, kind)
 
   # Level 1
   economic_code_l1 = economic_code[0]
-  if kind == GobiertoData::GobiertoBudgets::EXPENSE
+  if kind == GobiertoBudgetsData::GobiertoBudgets::EXPENSE
     functional_code_l1 = functional_code[0]
     functional_data[functional_code_l1] ? functional_data[functional_code_l1] += amount : functional_data[functional_code_l1] = amount
   end
@@ -122,8 +122,8 @@ end
 
 functional_data, economic_data = normalize_data(json_data, kind)
 
-output_data = hydratate(data: functional_data, area_name: GobiertoData::GobiertoBudgets::FUNCTIONAL_AREA_NAME, base_data: base_data, kind: kind) +
-  hydratate(data: economic_data, area_name: GobiertoData::GobiertoBudgets::ECONOMIC_AREA_NAME, base_data: base_data, kind: kind)
+output_data = hydratate(data: functional_data, area_name: GobiertoBudgetsData::GobiertoBudgets::FUNCTIONAL_AREA_NAME, base_data: base_data, kind: kind) +
+  hydratate(data: economic_data, area_name: GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME, base_data: base_data, kind: kind)
 
 File.write(output_file, output_data.to_json)
 

--- a/operations/gobierto_budgets/transform-planned/run.rb
+++ b/operations/gobierto_budgets/transform-planned/run.rb
@@ -27,7 +27,7 @@ end
 
 input_file = ARGV[0]
 output_file = ARGV[1]
-kind = ARGV[2] == 'I' ? GobiertoData::GobiertoBudgets::INCOME : GobiertoData::GobiertoBudgets::EXPENSE
+kind = ARGV[2] == 'I' ? GobiertoBudgetsData::GobiertoBudgets::INCOME : GobiertoBudgetsData::GobiertoBudgets::EXPENSE
 year = ARGV[3].to_i
 
 puts "[START] transform-planned/run.rb with file=#{input_file} output=#{output_file} year=#{year}"
@@ -35,7 +35,7 @@ puts "[START] transform-planned/run.rb with file=#{input_file} output=#{output_f
 json_data = JSON.parse(File.read(input_file))
 
 place = INE::Places::Place.find_by_slug('reus')
-population = GobiertoData::GobiertoBudgets::Population.get(place.id, year)
+population = GobiertoBudgetsData::GobiertoBudgets::Population.get(place.id, year)
 
 base_data = {
   organization_id: place.id,
@@ -58,7 +58,7 @@ def normalize_data(data, kind)
 end
 
 def process_row(row, functional_data, economic_data, kind)
-  amount = kind == GobiertoData::GobiertoBudgets::INCOME ? row["PREVISIONS INGRESSOS INICIALS"].to_f : row["CRÈDITS INICIALS"].to_f
+  amount = kind == GobiertoBudgetsData::GobiertoBudgets::INCOME ? row["PREVISIONS INGRESSOS INICIALS"].to_f : row["CRÈDITS INICIALS"].to_f
   amount = amount.round(2)
   functional_code = row["PROGRAMA"].try(:strip)
   economic_code   = row["ECONÒMICA"].strip
@@ -71,7 +71,7 @@ def process_row(row, functional_data, economic_data, kind)
 
   # Level 3
   economic_code_l3 = economic_code[0..2]
-  if kind == GobiertoData::GobiertoBudgets::EXPENSE
+  if kind == GobiertoBudgetsData::GobiertoBudgets::EXPENSE
     functional_code_l3 = functional_code[0..2]
     functional_data[functional_code_l3] ? functional_data[functional_code_l3] += amount : functional_data[functional_code_l3] = amount
   end
@@ -79,7 +79,7 @@ def process_row(row, functional_data, economic_data, kind)
 
   # Level 2
   economic_code_l2 = economic_code[0..1]
-  if kind == GobiertoData::GobiertoBudgets::EXPENSE
+  if kind == GobiertoBudgetsData::GobiertoBudgets::EXPENSE
     functional_code_l2 = functional_code[0..1]
     functional_data[functional_code_l2] ? functional_data[functional_code_l2] += amount : functional_data[functional_code_l2] = amount
   end
@@ -87,7 +87,7 @@ def process_row(row, functional_data, economic_data, kind)
 
   # Level 1
   economic_code_l1 = economic_code[0]
-  if kind == GobiertoData::GobiertoBudgets::EXPENSE
+  if kind == GobiertoBudgetsData::GobiertoBudgets::EXPENSE
     functional_code_l1 = functional_code[0]
     functional_data[functional_code_l1] ? functional_data[functional_code_l1] += amount : functional_data[functional_code_l1] = amount
   end
@@ -122,8 +122,8 @@ end
 
 functional_data, economic_data = normalize_data(json_data, kind)
 
-output_data = hydratate(data: functional_data, area_name: GobiertoData::GobiertoBudgets::FUNCTIONAL_AREA_NAME, base_data: base_data, kind: kind) +
-  hydratate(data: economic_data, area_name: GobiertoData::GobiertoBudgets::ECONOMIC_AREA_NAME, base_data: base_data, kind: kind)
+output_data = hydratate(data: functional_data, area_name: GobiertoBudgetsData::GobiertoBudgets::FUNCTIONAL_AREA_NAME, base_data: base_data, kind: kind) +
+  hydratate(data: economic_data, area_name: GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME, base_data: base_data, kind: kind)
 
 File.write(output_file, output_data.to_json)
 


### PR DESCRIPTION
Related to PopulateTools/issues#1352

This PR replaces namespaces of `GobiertoData` with `GobiertoBudgetsData` and updates the gems dependency to point `gobierto_budgets_data` instead of `gobierto_data`